### PR TITLE
Migrate to MCP CLI 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-roblox-docs"
-version = "3.3.1"
+version = "3.3.2"
 description = "MCP Server for Roblox Studio Documentation - Complete API reference, FastFlags, Open Cloud API, Luau language docs, DataTypes, Libraries, DevForum search, and more"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -9,7 +9,7 @@ authors = [{ name = "Native" }]
 keywords = ["roblox", "mcp", "documentation", "api", "studio", "luau", "opencloud", "fastflags", "datatypes"]
 
 dependencies = [
-    "mcp[cli]>=1.2.0",
+    "mcp[cli]>=2.0.0",
     "httpx>=0.27.0",
     "orjson>=3.10.0",
     "platformdirs>=4.0.0",

--- a/src/server.py
+++ b/src/server.py
@@ -65,7 +65,7 @@ from typing import Any
 
 import httpx
 import platformdirs
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from src.data.loader import DataLoader
 from src.data.syncer import DataSyncer, AVAILABLE_LANGUAGES, LUAU_DOCS_TOPICS
@@ -125,7 +125,7 @@ logger = logging.getLogger("mcp-roblox-docs")
 CACHE_DIR = Path(platformdirs.user_cache_dir("mcp-roblox-docs"))
 
 # Initialize FastMCP server
-mcp = FastMCP("roblox-docs")
+mcp = MCPServer("roblox-docs")                                                          
 
 # Global state (initialized on startup)
 _loader: DataLoader | None = None


### PR DESCRIPTION
Currently the mcp requires the uvx flag `--with mcp<2` to function as expected, this simple fix directly addresses that